### PR TITLE
faastest log output to stdout as well

### DIFF
--- a/report/output/stdio/top.go
+++ b/report/output/stdio/top.go
@@ -3,7 +3,7 @@ package stdio
 import (
 	"github.com/nuweba/faasbenchmark/report"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 type Top struct {
@@ -18,5 +18,5 @@ func New(stdoutWriter io.Writer) (report.Top, error) {
 }
 
 func (t *Top) LogWriter() (io.Writer, error) {
-	return ioutil.Discard, nil
+	return os.Stdout, nil
 }


### PR DESCRIPTION
@nwb-adir when running faasbenchmark in CI pipeline, id like to be able to see the error in the pipeline output, without having to dig through log files.