### PR TITLE
attempt to remove stack only if deployment was successful

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -189,7 +189,8 @@ func runOneTest(gConfig *config.Global, testId string) error {
 	go handleSignals(gConfig, stack, stackRemoved)
 	defer func() {
 		if err != nil {
-			gConfig.Logger.Error("error during test run, removing stack", zap.String("err", err.Error()))
+			// error deploying stack, will not remove it
+			return
 		}
 		gConfig.Logger.Info("removing stack", zap.String("name", stack.StackId()))
 		// err will be returned by wrapping function's return statement


### PR DESCRIPTION
Before this fix, when deploying `IncreasingLoadLvl1` for example, and maven is not installed on my machine, I experience 10 retry attempts to remove the stack even though it failed to deploy.